### PR TITLE
#442: dor, paca 제거

### DIFF
--- a/supported_coin.json
+++ b/supported_coin.json
@@ -54407,33 +54407,5 @@
       "klayCard": false,
       "software": true
     }
-  },
-  {
-    "iconUrl": "https://info-repo.dcentwallet.com/images/coins/networks/network_dor.png",
-    "symbol": "DOR",
-    "name": "DOR",
-    "type": "Metagraph",
-    "contract": "DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM",
-    "support": {
-      "biometric": true,
-      "card": false,
-      "ethCard": false,
-      "klayCard": false,
-      "software": true
-    }
-  },
-  {
-    "iconUrl": "https://info-repo.dcentwallet.com/images/coins/networks/network_elpaca.png",
-    "symbol": "PACA",
-    "name": "El Paca",
-    "type": "Metagraph",
-    "contract": "DAG7ChnhUF7uKgn8tXy45aj4zn9AFuhaZr8VXY43",
-    "support": {
-      "biometric": true,
-      "card": false,
-      "ethCard": false,
-      "klayCard": false,
-      "software": true
-    }
   }
 ]


### PR DESCRIPTION
constellation 의 메인넷만 출시되고 토큰은 출시되지 않아
supported_coin.json에서 dor, paca 제거하였습니다.